### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Java Object Oriented Querying (JOOQ) Test demo application.
+JOOQ  Object Oriented Querying (JOOQ) Test demo application.
 
 Demo application showing how to setup a database, an IntelliJ project using Maven.
 Just three plug-ins and one dependency are needed: the JOOQ Maven Plug-in to generate our meta-model from an existing database, the Build Helper Plug-in for Maven to add the generated-sources-directory as a source directory to the Maven build environment, the Exec Maven Plug-in to execute the Java programs in a separate process and the dependency for the JDBC connector – in this case: MySQL.


### PR DESCRIPTION
Thank you again very much for publishing this repository about jOOQ

Your repository (and possibly blog posts) refers to jOOQ as “Java Object Oriented Querying”. This is not the official name of our product, as this would infringe Oracle’s trademarks for “Java”. The jOOQ acronym stands for “JOOQ Object Oriented Querying”.